### PR TITLE
Cleanup round 2: HDF5 field table unification, parameter hardening, const-correctness

### DIFF
--- a/src/core_mymalloc.c
+++ b/src/core_mymalloc.c
@@ -24,7 +24,7 @@
 static long Nblocks = 0;
 static void *Table[MAXBLOCKS];
 static size_t SizeTable[MAXBLOCKS];
-static size_t TotMem = 0, HighMarkMem = 0, OldPrintedHighMark = 0;
+static size_t TotMem = 0, HighMarkMem = 0;
 
 /* file-local helpers */
 static long find_block(const void *p);
@@ -106,7 +106,7 @@ void *myrealloc(void *p, size_t n)
     }
     void *newp = realloc(Table[iblock], n);
     if(newp == NULL) {
-        fprintf(stderr, "Error: Failed to re-allocate memory for %g MB (old size = %g MB)\n",  n / (1024.0 * 1024.0), SizeTable[Nblocks-1]/ (1024.0 * 1024.0) );
+        fprintf(stderr, "Error: Failed to re-allocate memory for %g MB (old size = %g MB)\n",  n / (1024.0 * 1024.0), SizeTable[iblock]/ (1024.0 * 1024.0) );
         ABORT(MALLOC_FAILURE);
     }
     Table[iblock] = newp;
@@ -186,16 +186,10 @@ void print_allocated(void)
     return;
 }
 
-/* set_and_print_highwater_mark -- update HighMarkMem; print if new 10 MB band crossed. */
+/* set_and_print_highwater_mark -- track the peak tracked-heap usage. */
 static void set_and_print_highwater_mark(void)
 {
     if(TotMem > HighMarkMem) {
         HighMarkMem = TotMem;
-        if(HighMarkMem > OldPrintedHighMark + 10 * 1024.0 * 1024.0) {
-#ifdef VERBOSE
-#endif
-            OldPrintedHighMark = HighMarkMem;
-        }
     }
-    return;
 }

--- a/src/core_read_parameter_file.c
+++ b/src/core_read_parameter_file.c
@@ -57,7 +57,7 @@ static int compare_ints_descending (const void* p1, const void* p2)
 int read_parameter_file(const char *fname, struct params *run_params)
 {
     int errorFlag = 0;
-    int *used_tag = 0;
+    int *used_tag = NULL;
     char my_treetype[MAX_STRING_LEN], my_outputformat[MAX_STRING_LEN], my_forest_dist_scheme[MAX_STRING_LEN];
     int NParam = 0;
     char ParamTag[MAXTAGS][MAXTAGLEN + 1];

--- a/src/core_read_parameter_file.c
+++ b/src/core_read_parameter_file.c
@@ -295,16 +295,29 @@ int read_parameter_file(const char *fname, struct params *run_params)
         }
 
         if(j >= 0) {
+            /* strtod/strtol instead of atof/atoi: a malformed numeric value
+               (e.g. a typo like "O.05") must be a startup error, not a silent 0. */
+            char *endptr = NULL;
             switch (ParamID[j])
                 {
                 case DOUBLE:
-                    *((double *) ParamAddr[j]) = atof(buf2);
+                    *((double *) ParamAddr[j]) = strtod(buf2, &endptr);
+                    if(endptr == buf2 || *endptr != '\0') {
+                        fprintf(stderr, "Error in file %s:   Value '%s' for parameter '%s' is not a valid number.\n",
+                                fname, buf2, buf1);
+                        errorFlag = 1;
+                    }
                     break;
                 case STRING:
                     snprintf(ParamAddr[j], MAX_STRING_LEN, "%s", buf2);
                     break;
                 case INT:
-                    *((int *) ParamAddr[j]) = atoi(buf2);
+                    *((int *) ParamAddr[j]) = (int) strtol(buf2, &endptr, 10);
+                    if(endptr == buf2 || *endptr != '\0') {
+                        fprintf(stderr, "Error in file %s:   Value '%s' for parameter '%s' is not a valid integer.\n",
+                                fname, buf2, buf1);
+                        errorFlag = 1;
+                    }
                     break;
                 }
         } else {

--- a/src/core_save.c
+++ b/src/core_save.c
@@ -98,8 +98,10 @@ int32_t save_galaxies(const int64_t task_forestnr, const int numgals, struct hal
 {
     int32_t status = EXIT_FAILURE;
 
-    // Reset the output galaxy count.
-    int32_t OutputGalCount[run_params->SimMaxSnaps];
+    // Reset the output galaxy count. SimMaxSnaps is validated to be
+    // < ABSOLUTEMAXSNAPS at parameter-read time, so a fixed array is safe
+    // (and avoids a variable-length array on the stack).
+    int32_t OutputGalCount[ABSOLUTEMAXSNAPS];
     for(int32_t snap_idx = 0; snap_idx < run_params->SimMaxSnaps; snap_idx++) {
         OutputGalCount[snap_idx] = 0;
     }

--- a/src/io/save_gals_hdf5.c
+++ b/src/io/save_gals_hdf5.c
@@ -30,7 +30,9 @@
 #include "../sage.h"
 
 
-#define NUM_OUTPUT_FIELDS 82
+/* Field count derived from the single source of truth in save_gals_hdf5_fields.h */
+#define SAGE_FIELD_COUNT(dset, field, ctype, h5t, desc, unit) + 1
+#define NUM_OUTPUT_FIELDS (0 GALAXY_OUTPUT_FIELDS(SAGE_FIELD_COUNT))
 
 #define NUM_GALS_PER_BUFFER 8192
 
@@ -385,89 +387,10 @@ int32_t initialize_hdf5_galaxy_files(const int filenr, struct save_info *save_in
     // Now we need to malloc all the arrays **inside** the GALAXY_OUTPUT struct.
     for(int32_t snap_idx = 0; snap_idx < run_params->NumSnapOutputs; snap_idx++) {
 
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SnapNum);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Type);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, GalaxyIndex);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, CentralGalaxyIndex);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SAGEHaloIndex);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SAGETreeIndex);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SimulationHaloIndex);
+#define SAGE_FIELD_MALLOC(dset, field, ctype, h5t, desc, unit) MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, field);
+        GALAXY_OUTPUT_FIELDS(SAGE_FIELD_MALLOC)
+#undef SAGE_FIELD_MALLOC
         MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, TaskForestNr);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, mergeType);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, mergeIntoID);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, mergeIntoSnapNum);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, dT);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Posx);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Posy);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Posz);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Velx);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Vely);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Velz);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Spinx);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Spiny);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Spinz);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Len);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Mvir);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, CentralMvir);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Rvir);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Vvir);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Vmax);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, VelDisp);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, ColdGas);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, StellarMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, BulgeMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, HotGas);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, EjectedMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, BlackHoleMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, ICS);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsColdGas);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsStellarMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsBulgeMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsHotGas);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsEjectedMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsICS);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SfrDisk);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SfrBulge);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SfrDiskZ);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SfrBulgeZ);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, DiskScaleRadius);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, BulgeRadius);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MergerBulgeRadius);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, InstabilityBulgeRadius);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MergerBulgeMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, InstabilityBulgeMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Cooling);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Heating);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, QuasarModeBHaccretionMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, TimeOfLastMajorMerger);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, TimeOfLastMinorMerger);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, OutflowRate);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, infallMvir);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, infallVvir);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, infallVmax);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, infallStellarMass);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Regime);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, CGMgas);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsCGMgas);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MassLoading);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, H2gas);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, H1gas);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, tcool);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, tff);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, tcool_over_tff);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, tdeplete);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, H2DepletionTime_Gyr);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, RcoolToRvir);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, TimeOfInfall);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, FFBRegime);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Concentration);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, mdot_cool);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, mdot_stream);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, ICS_disrupt);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, ICS_accrete);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, ICS_sum_mt);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, g_max);
-        MALLOC_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, r_heat);
         
         /* Conditionally allocate cumulative SFH arrays if SaveFullSFH is enabled */
         if(run_params->SaveFullSFH) {
@@ -727,89 +650,10 @@ int32_t finalize_hdf5_galaxy_files(const struct forest_info *forest_info, struct
 
     for(int32_t snap_idx = 0; snap_idx < run_params->NumSnapOutputs; snap_idx++) {
 
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SnapNum);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Type);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, GalaxyIndex);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, CentralGalaxyIndex);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SAGEHaloIndex);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SAGETreeIndex);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SimulationHaloIndex);
+#define SAGE_FIELD_FREE(dset, field, ctype, h5t, desc, unit) FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, field);
+        GALAXY_OUTPUT_FIELDS(SAGE_FIELD_FREE)
+#undef SAGE_FIELD_FREE
         FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, TaskForestNr);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, mergeType);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, mergeIntoID);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, mergeIntoSnapNum);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, dT);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Posx);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Posy);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Posz);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Velx);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Vely);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Velz);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Spinx);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Spiny);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Spinz);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Len);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Mvir);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, CentralMvir);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Rvir);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Vvir);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Vmax);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, VelDisp);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, ColdGas);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, StellarMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, BulgeMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, HotGas);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, EjectedMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, BlackHoleMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, ICS);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsColdGas);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsStellarMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsBulgeMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsHotGas);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsEjectedMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsICS);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SfrDisk);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SfrBulge);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SfrDiskZ);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, SfrBulgeZ);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, DiskScaleRadius);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, BulgeRadius);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MergerBulgeRadius);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, InstabilityBulgeRadius);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MergerBulgeMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, InstabilityBulgeMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Cooling);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Heating);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, QuasarModeBHaccretionMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, TimeOfLastMajorMerger);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, TimeOfLastMinorMerger);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, OutflowRate);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, infallMvir);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, infallVvir);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, infallVmax);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, infallStellarMass);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Regime);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, CGMgas);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MetalsCGMgas);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, MassLoading);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, H2gas);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, H1gas);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, tcool);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, tff);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, tcool_over_tff);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, tdeplete);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, H2DepletionTime_Gyr);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, RcoolToRvir);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, TimeOfInfall);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, FFBRegime);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, Concentration);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, mdot_cool);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, mdot_stream);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, ICS_disrupt);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, ICS_accrete);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, ICS_sum_mt);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, g_max);
-        FREE_GALAXY_OUTPUT_INNER_ARRAY(snap_idx, r_heat);
         
         /* Conditionally free full SFH arrays if they were allocated */
         /* Conditionally free SFH arrays if they were allocated */
@@ -943,102 +787,30 @@ static int32_t generate_field_metadata(char (*field_names)[MAX_STRING_LEN], char
                                 char (*field_units)[MAX_STRING_LEN], hsize_t *field_dtypes)
 {
 
-    char tmp_names[NUM_OUTPUT_FIELDS][MAX_STRING_LEN] = {"SnapNum", "Type", "GalaxyIndex", "CentralGalaxyIndex", "SAGEHaloIndex",
-                                                         "SAGETreeIndex", "SimulationHaloIndex", "mergeType", "mergeIntoID",
-                                                         "mergeIntoSnapNum", "dT", "Posx", "Posy", "Posz", "Velx", "Vely", "Velz",
-                                                         "Spinx", "Spiny", "Spinz", "Len", "Mvir", "CentralMvir", "Rvir", "Vvir",
-                                                         "Vmax", "VelDisp", "ColdGas", "StellarMass", "BulgeMass", "HotGas", "EjectedMass",
-                                                         "BlackHoleMass", "IntraClusterStars", "MetalsColdGas", "MetalsStellarMass", "MetalsBulgeMass",
-                                                         "MetalsHotGas", "MetalsEjectedMass", "MetalsIntraClusterStars", "SfrDisk", "SfrBulge", "SfrDiskZ",
-                                                         "SfrBulgeZ", "DiskRadius", "BulgeRadius", "MergerBulgeRadius", "InstabilityBulgeRadius", "MergerBulgeMass", "InstabilityBulgeMass", "Cooling", "Heating", "QuasarModeBHaccretionMass",
-                                                         "TimeOfLastMajorMerger", "TimeOfLastMinorMerger", "OutflowRate", "infallMvir",
-                                                         "infallVvir", "infallVmax", "infallStellarMass", "Regime", "CGMgas", "MetalsCGMgas", "MassLoading", "H2gas", "H1gas",
-                                                         "tcool", "tff", "tcool_over_tff", "tdeplete", "H2DepletionTime_Gyr", "RcoolToRvir", "TimeOfInfall", "FFBRegime", "Concentration", "mdot_cool", "mdot_stream",
-                                                         "ICS_disrupt", "ICS_accrete", "ICS_sum_mt", "g_max", "r_heat"};
+    /* All four tables generated in output order from GALAXY_OUTPUT_FIELDS. */
+    char tmp_names[NUM_OUTPUT_FIELDS][MAX_STRING_LEN] = {
+#define SAGE_FIELD_NAME(dset, field, ctype, h5t, desc, unit) #dset,
+        GALAXY_OUTPUT_FIELDS(SAGE_FIELD_NAME)
+#undef SAGE_FIELD_NAME
+    };
 
-    // Must accurately describe what exactly each field is and any special considerations.
-    char tmp_descriptions[NUM_OUTPUT_FIELDS][MAX_STRING_LEN] = {"Snapshot the galaxy is located at.",
-                                                                "0: Central galaxy of the main FoF halo. 1: Central of a sub-halo. 2: Orphan galaxy that will merge within the current timestep.",
-                                                                "Galaxy ID, unique across all trees and files. Calculated as local galaxy number + tree number * factor + file number * factor ",
-                                                                "GalaxyIndex of the central galaxy within this galaxy's FoF group.  Calculated the same as 'GalaxyIndex'.",
-                                                                "Halo number from the restructured trees. This is different to the tree file because we order the trees. Note: This is the host halo, not necessarily the main FoF halo.",
-                                                                "Tree number this galaxy belongs to.", "Most bound particle ID from the tree files.",
-                                                                "Denotes how this galaxy underwent a merger. 0: None. 1: Minor merger. 2: Major merger. 3: Disk instability. 4: Disrupt to intra-cluster stars.",
-                                                                "Galaxy ID this galaxy is merging into.",
-                                                                "Snapshot number of the galaxy this galaxy is merging into.",
-                                                                "Time between this snapshot and when the galaxy was last evolved.",
-                                                                "Galaxy spatial x position.", "Galaxy spatial y position.",
-                                                                "Galaxy spatial z position.", "Galaxy velocity in x direction.",
-                                                                "Galaxy velocity in y direction.", "Galaxy velocity in z direction.",
-                                                                "Halo spin in the x direction.", "Halo spin in the y direction.",
-                                                                "Halo spin in the z direction.", "Number of particles in this galaxy's halo.",
-                                                                "Virial mass of this galaxy's halo.", "Virial mass of the main FoF halo.",
-                                                                "Virial radius of this galaxy's halo.", "Virial velocity of this galaxy's halo.",
-                                                                "Maximum circular speed for this galaxy's halo.", "Velocity dispersion for this galaxy's halo.",
-                                                                "Mass of gas in the cold reseroivr.", "Mass of stars.",
-                                                                "Mass of stars in the bulge. Bulge stars are added either through disk instabilities or mergers.",
-                                                                "Mass of gas in the hot reservoir.", "Mass of gass in the ejected reseroivr.",
-                                                                "Mass of this galaxy's black hole.", "Mass of intra-cluster stars.", "Mass of metals in the cold reseroivr.",
-                                                                "Mass of metals in stars.", "Mass of metals in the bulge.",
-                                                                "Mass of metals in the hot reservoir.", "Mass of metals in the ejected reseroivr.",
-                                                                "Mass of metals in intra-cluster stars.", "Star formation rate within the disk.",
-                                                                "Star formation rate within the bulge.", "Average metallicity of star-forming disk gas.",
-                                                                "Average metallicity of star-forming bulge gas.", "Disk scale radius based on Mo, Shude & White (1998)", "Bulge scale radius based on Lange et al. (2015), Shen et al. (2003)",
-                                                                "Bulge radius formed from mergers (classical bulge).", "Bulge radius formed from disk instabilities (pseudo-bulge).",
-                                                                "Mass of stars in the bulge formed from mergers.", "Mass of stars in the bulge formed from disk instabilities.",
-                                                                "Energy rate for gas cooling in the galaxy.", "Energy rate for gas heating in the galaxy.",
-                                                                "Mass that this galaxy's black hole accreted during the last time step.",
-                                                                "Time since this galaxy had a major merger.", "Time since this galaxy had a minor merger.",
-                                                                "Rate at which cold gas is reheated to hot gas.",
-                                                                "Virial mass of this galaxy's halo at the previous timestep.",
-                                                                "Virial velocity of this galaxy's halo at the previous timestep.",
-                                                                "Maximum circular speed of this galaxy's halo at the previous timestep.",
-                                                                "Stellar mass of this galaxy at the time it became a satellite.",
-                                                                "Regime of gas accretion onto this galaxy's halo: 0 = CGM-regime 1 = ICM-regime.",
-                                                                "Mass of gas in the circum-galactic medium (CGM).",
-                                                                "Mass of metals in the circum-galactic medium (CGM).",
-                                                                "Mass loading factor defined as the ratio of outflow rate to star formation rate.",
-                                                                "Mass of molecular hydrogen (H2) in the cold gas reservoir.",
-                                                                "Mass of atomic hydrogen (HI) in the cold gas reservoir.",
-                                                                "Cooling time of the CGM gas in the halo.",
-                                                                "Free-fall time of the CGM gas in the halo.",
-                                                                "Ratio of cooling time to free-fall time of the CGM gas in the halo.",
-                                                                "Depletion time of the CGM gas reservoir.",
-                                                                "H2 depletion time from the K13 prescription. -1 if not applicable.",
-                                                                "Ratio of the cooling radius to the virial radius of the halo.",
-                                                                "Time when the galaxy last became a satellite galaxy.",
-                                                                "FFB Regime of this galaxy's halo: 0 = Normal halo 1 = FFB halo.", "NFW halo concentration parameter from Ishiyama+21 c-M relation.", "Cooling rate of hot halo gas.", "Cooling rate of cold streams.",
-                                                                "Cumulative stellar mass disrupted to ICS (tracks assembly).", "Cumulative ICS accreted from satellites (tracks assembly).",
-                                                                "Mass-weighted sum m*t (code time) at ICS deposition; divide by (ICS_disrupt+ICS_accrete) for mean assembly lookback.",
-                                                                "Maximum g value for this galaxy's halo across all snapshots.",
-                                                                "AGN radio-mode heating radius (ratchet, capped at Rvir in the CGM regime). Cooling is suppressed at r < r_heat."};
+    char tmp_descriptions[NUM_OUTPUT_FIELDS][MAX_STRING_LEN] = {
+#define SAGE_FIELD_DESC(dset, field, ctype, h5t, desc, unit) desc,
+        GALAXY_OUTPUT_FIELDS(SAGE_FIELD_DESC)
+#undef SAGE_FIELD_DESC
+    };
 
-    char tmp_units[NUM_OUTPUT_FIELDS][MAX_STRING_LEN] = {"Unitless", "Unitless", "Unitless", "Unitless", "Unitless",
-                                                         "Unitless", "Unitless", "Unitless", "Unitless",
-                                                         "Unitless", "Myr", "Mpc/h", "Mpc/h", "Mpc/h", "km/s", "km/s", "km/s",
-                                                         "Mpc * km/s", "Mpc * km/s", "Mpc * km/s", "Unitless", "1.0e10 Msun/h", "1.0e10 Msun/h",
-                                                         "Mpc/h", "km/s",
-                                                         "km/s", "km/s", "1.0e10 Msun/h", "1.0e10 Msun/h", "1.0e10 Msun/h", "1.0e10 Msun/h", "1.0e10 Msun/h",
-                                                         "1.0e10 Msun/h", "1.0e10 Msun/h", "1.0e10 Msun/h", "1.0e10 Msun/h", "1.0e10 Msun/h",
-                                                         "1.0e10 Msun/h", "1.0e10 Msun/h", "1.0e10 Msun/h", "Msun/yr", "Msun/yr", "Msun/yr",
-                                                         "Msun/yr", "Mpc/h", "Mpc/h", "Mpc/h", "Mpc/h", "1.0e10 Msun/h", "1.0e10 Msun/h", "erg/s", "erg/s", "1.0e10 Msun/h",
-                                                         "Myr", "Myr", "Msun/yr", "1.0e10 Msun/yr", "km/s", "km/s", "1.0e10 Msun/h", "Unitless", "1.0e10 Msun/h", "1.0e10 Msun/h", "Unitless", "1.0e10 Msun/h", "1.0e10 Msun/h",
-                                                         "Myr", "Myr", "Unitless", "Myr", "Gyr", "Unitless", "Myr", "Unitless", "Unitless", "1.0e10 Msun/yr", "1.0e10 Msun/yr",
-                                                         "1.0e10 Msun/h", "1.0e10 Msun/h", "1.0e10 Msun/h * code_time", "1.0e10 Msun/h", "Mpc/h"};
+    char tmp_units[NUM_OUTPUT_FIELDS][MAX_STRING_LEN] = {
+#define SAGE_FIELD_UNIT(dset, field, ctype, h5t, desc, unit) unit,
+        GALAXY_OUTPUT_FIELDS(SAGE_FIELD_UNIT)
+#undef SAGE_FIELD_UNIT
+    };
 
-    // These are the HDF5 datatypes for each field.
-    hsize_t tmp_dtype[NUM_OUTPUT_FIELDS] = {H5T_NATIVE_INT, H5T_NATIVE_INT, H5T_NATIVE_LLONG, H5T_NATIVE_LLONG, H5T_NATIVE_INT,
-                                            H5T_NATIVE_INT, H5T_NATIVE_LLONG, H5T_NATIVE_INT, H5T_NATIVE_INT,
-                                            H5T_NATIVE_INT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT,
-                                            H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_INT, H5T_NATIVE_FLOAT,
-                                            H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT,
-                                            H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT,
-                                            H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT,
-                                            H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT,
-                                            H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT,
-                                            H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_INT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT,
-                                            H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_INT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT,
-                                            H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, H5T_NATIVE_DOUBLE, H5T_NATIVE_FLOAT};
+    hsize_t tmp_dtype[NUM_OUTPUT_FIELDS] = {
+#define SAGE_FIELD_DTYPE(dset, field, ctype, h5t, desc, unit) h5t,
+        GALAXY_OUTPUT_FIELDS(SAGE_FIELD_DTYPE)
+#undef SAGE_FIELD_DTYPE
+    };
     for(int32_t i = 0; i < NUM_OUTPUT_FIELDS; i++) {
         memcpy(field_names[i], tmp_names[i], MAX_STRING_LEN);
         memcpy(field_descriptions[i], tmp_descriptions[i], MAX_STRING_LEN);
@@ -1361,88 +1133,9 @@ static int32_t trigger_buffer_write(const int32_t snap_idx, const int32_t num_to
 
     // We now need to write each property to file.  This is performed in a stack of macros because
     // it's not possible to loop through the members of a struct.
-    EXTEND_AND_WRITE_GALAXY_DATASET(SnapNum);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Type);
-    EXTEND_AND_WRITE_GALAXY_DATASET(GalaxyIndex);
-    EXTEND_AND_WRITE_GALAXY_DATASET(CentralGalaxyIndex);
-    EXTEND_AND_WRITE_GALAXY_DATASET(SAGEHaloIndex);
-    EXTEND_AND_WRITE_GALAXY_DATASET(SAGETreeIndex);
-    EXTEND_AND_WRITE_GALAXY_DATASET(SimulationHaloIndex);
-    EXTEND_AND_WRITE_GALAXY_DATASET(mergeType);
-    EXTEND_AND_WRITE_GALAXY_DATASET(mergeIntoID);
-    EXTEND_AND_WRITE_GALAXY_DATASET(mergeIntoSnapNum);
-    EXTEND_AND_WRITE_GALAXY_DATASET(dT);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Posx);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Posy);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Posz);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Velx);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Vely);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Velz);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Spinx);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Spiny);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Spinz);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Len);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Mvir);
-    EXTEND_AND_WRITE_GALAXY_DATASET(CentralMvir);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Rvir);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Vvir);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Vmax);
-    EXTEND_AND_WRITE_GALAXY_DATASET(VelDisp);
-    EXTEND_AND_WRITE_GALAXY_DATASET(ColdGas);
-    EXTEND_AND_WRITE_GALAXY_DATASET(StellarMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(BulgeMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(HotGas);
-    EXTEND_AND_WRITE_GALAXY_DATASET(EjectedMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(BlackHoleMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(ICS);
-    EXTEND_AND_WRITE_GALAXY_DATASET(MetalsColdGas);
-    EXTEND_AND_WRITE_GALAXY_DATASET(MetalsStellarMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(MetalsBulgeMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(MetalsHotGas);
-    EXTEND_AND_WRITE_GALAXY_DATASET(MetalsEjectedMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(MetalsICS);
-    EXTEND_AND_WRITE_GALAXY_DATASET(SfrDisk);
-    EXTEND_AND_WRITE_GALAXY_DATASET(SfrBulge);
-    EXTEND_AND_WRITE_GALAXY_DATASET(SfrDiskZ);
-    EXTEND_AND_WRITE_GALAXY_DATASET(SfrBulgeZ);
-    EXTEND_AND_WRITE_GALAXY_DATASET(DiskScaleRadius);
-    EXTEND_AND_WRITE_GALAXY_DATASET(BulgeRadius);
-    EXTEND_AND_WRITE_GALAXY_DATASET(MergerBulgeRadius);
-    EXTEND_AND_WRITE_GALAXY_DATASET(InstabilityBulgeRadius);
-    EXTEND_AND_WRITE_GALAXY_DATASET(MergerBulgeMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(InstabilityBulgeMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Cooling);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Heating);
-    EXTEND_AND_WRITE_GALAXY_DATASET(QuasarModeBHaccretionMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(TimeOfLastMajorMerger);
-    EXTEND_AND_WRITE_GALAXY_DATASET(TimeOfLastMinorMerger);
-    EXTEND_AND_WRITE_GALAXY_DATASET(OutflowRate);
-    EXTEND_AND_WRITE_GALAXY_DATASET(infallMvir);
-    EXTEND_AND_WRITE_GALAXY_DATASET(infallVvir);
-    EXTEND_AND_WRITE_GALAXY_DATASET(infallVmax);
-    EXTEND_AND_WRITE_GALAXY_DATASET(infallStellarMass);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Regime);
-    EXTEND_AND_WRITE_GALAXY_DATASET(CGMgas);
-    EXTEND_AND_WRITE_GALAXY_DATASET(MetalsCGMgas);
-    EXTEND_AND_WRITE_GALAXY_DATASET(MassLoading);
-    EXTEND_AND_WRITE_GALAXY_DATASET(H2gas);
-    EXTEND_AND_WRITE_GALAXY_DATASET(H1gas);
-    EXTEND_AND_WRITE_GALAXY_DATASET(tcool);
-    EXTEND_AND_WRITE_GALAXY_DATASET(tff);
-    EXTEND_AND_WRITE_GALAXY_DATASET(tcool_over_tff);
-    EXTEND_AND_WRITE_GALAXY_DATASET(tdeplete);
-    EXTEND_AND_WRITE_GALAXY_DATASET(H2DepletionTime_Gyr);
-    EXTEND_AND_WRITE_GALAXY_DATASET(RcoolToRvir);
-    EXTEND_AND_WRITE_GALAXY_DATASET(TimeOfInfall);
-    EXTEND_AND_WRITE_GALAXY_DATASET(FFBRegime);
-    EXTEND_AND_WRITE_GALAXY_DATASET(Concentration);
-    EXTEND_AND_WRITE_GALAXY_DATASET(mdot_cool);
-    EXTEND_AND_WRITE_GALAXY_DATASET(mdot_stream);
-    EXTEND_AND_WRITE_GALAXY_DATASET(ICS_disrupt);
-    EXTEND_AND_WRITE_GALAXY_DATASET(ICS_accrete);
-    EXTEND_AND_WRITE_GALAXY_DATASET(ICS_sum_mt);
-    EXTEND_AND_WRITE_GALAXY_DATASET(g_max);
-    EXTEND_AND_WRITE_GALAXY_DATASET(r_heat);
+#define SAGE_FIELD_WRITE(dset, field, ctype, h5t, desc, unit) EXTEND_AND_WRITE_GALAXY_DATASET(field);
+    GALAXY_OUTPUT_FIELDS(SAGE_FIELD_WRITE)
+#undef SAGE_FIELD_WRITE
 
 
     // Conditionally write cumulative SFH datasets if SaveFullSFH is enabled

--- a/src/io/save_gals_hdf5.h
+++ b/src/io/save_gals_hdf5.h
@@ -20,117 +20,23 @@ extern "C" {
 
 #include "../core_allvars.h"
 
+#include "save_gals_hdf5_fields.h"
+
+/* One heap array per output field per output snapshot (the write buffers).
+ * The per-dataset fields are generated from GALAXY_OUTPUT_FIELDS (see
+ * save_gals_hdf5_fields.h); TaskForestNr and the 2-D SFH arrays are the
+ * only members handled outside that list. */
 struct HDF5_GALAXY_OUTPUT
 {
-    int32_t   *SnapNum;
+#define SAGE_FIELD_STRUCT_MEMBER(dset, field, ctype, h5t, desc, unit) ctype *field;
+    GALAXY_OUTPUT_FIELDS(SAGE_FIELD_STRUCT_MEMBER)
+#undef SAGE_FIELD_STRUCT_MEMBER
 
-    int32_t *Type;
-    
-    long long   *GalaxyIndex;
-    long long   *CentralGalaxyIndex;
+    int64_t *TaskForestNr;   /* cpu-local forest number; internal bookkeeping, never written */
 
-    int32_t   *SAGEHaloIndex;
-    int32_t   *SAGETreeIndex;
-    
-    long long   *SimulationHaloIndex;
-    int64_t *TaskForestNr; /* MS: 17/9/2019 -- Tracks the cpu-local forest number */
-
-    int32_t  *mergeType;  /* 0=none; 1=minor merger; 2=major merger; 3=disk instability; 4=disrupt to ICS */
-    int32_t   *mergeIntoID;
-    int32_t   *mergeIntoSnapNum;
-    float *dT;
-
-    /* (sub)halo properties */
-    float *Posx;
-    float *Posy;
-    float *Posz;
-    float *Velx;
-    float *Vely;
-    float *Velz;
-    float *Spinx;
-    float *Spiny;
-    float *Spinz;
-    int32_t   *Len;
-    float *Mvir;
-    float *CentralMvir;
-    float *Rvir;
-    float *Vvir;
-    float *Vmax;
-    float *VelDisp;
-    
-    /* baryonic reservoirs */
-    float *ColdGas;
-    float *StellarMass;
-    float *BulgeMass;
-    float *HotGas;
-    float *EjectedMass;
-    float *BlackHoleMass;
-    float *ICS;
-    float *H2gas;
-    float *H1gas;
-
-    /* metals */
-    float *MetalsColdGas;
-    float *MetalsStellarMass;
-    float *MetalsBulgeMass;
-    float *MetalsHotGas;
-    float *MetalsEjectedMass;
-    float *MetalsICS;
-    float *MassLoading;
-    
-    /* to calculate magnitudes */
-    float *SfrDisk;
-    float *SfrBulge;
-    float *SfrDiskZ;
-    float *SfrBulgeZ;
-    
     /* cumulative star formation history - tracks stellar mass formed at each snapshot (controlled by SaveFullSFH) */
     float *SFHMassDisk;      /* Shape: [ngalaxies, SimMaxSnaps] - mass formed in disk at each snapshot */
     float *SFHMassBulge;     /* Shape: [ngalaxies, SimMaxSnaps] - mass formed in bulge at each snapshot */
-    
-    /* ICS assembly tracking - cumulative mass through each channel */
-    float *ICS_disrupt;      /* cumulative stellar mass disrupted to ICS */
-    float *ICS_accrete;      /* cumulative ICS accreted from satellites */
-    float *ICS_sum_mt;       /* mass-weighted sum m*t at deposition (code time); mean assembly time = ICS_sum_mt / (ICS_disrupt + ICS_accrete) */
-    
-    /* misc */
-    float *DiskScaleRadius;
-    float *BulgeRadius;
-    float *MergerBulgeRadius;
-    float *InstabilityBulgeRadius;
-    float *MergerBulgeMass;
-    float *InstabilityBulgeMass;
-    float *Cooling;
-    float *Heating;
-    float *QuasarModeBHaccretionMass;
-    float *TimeOfLastMajorMerger;
-    float *TimeOfLastMinorMerger;
-    float *OutflowRate;
-    
-    /* infall properties */
-    float *infallMvir;
-    float *infallVvir;
-    float *infallVmax;
-    float *infallStellarMass;
-    float *TimeOfInfall;
-
-    /* CGM properties */
-    int32_t *Regime;  /* 0 = CGM-regime 1 = ICM-regime */
-    float *CGMgas;
-    float *MetalsCGMgas;
-    float *tcool;
-    float *tff;
-    float *tcool_over_tff;
-    float *tdeplete;
-    float *H2DepletionTime_Gyr;
-    float *RcoolToRvir;
-
-    int32_t *FFBRegime;
-    float *Concentration;
-    float *mdot_cool;
-    float *mdot_stream;
-    double *g_max;
-    float *r_heat;          /* AGN radio-mode heating radius [Mpc/h], capped at Rvir in the CGM regime */
 };
     
     // Proto-Types //

--- a/src/io/save_gals_hdf5_fields.h
+++ b/src/io/save_gals_hdf5_fields.h
@@ -1,0 +1,266 @@
+/*
+ * save_gals_hdf5_fields.h -- single source of truth for the galaxy output fields.
+ *
+ * GALAXY_OUTPUT_FIELDS(X) applies X(DatasetName, StructField, ctype, h5_dtype,
+ * Description, Unit) to every per-galaxy HDF5 output dataset, in output order.
+ * The struct definition, the field metadata tables, the buffer alloc/free
+ * stacks, and the dataset write stack are all generated from this list, so
+ * adding an output field means adding exactly one entry here plus the one
+ * line in save_hdf5_galaxies() that fills the buffer value.
+ *
+ * Not listed here (special cases handled explicitly): TaskForestNr (internal
+ * per-tree bookkeeping, never written) and SFHMassDisk/SFHMassBulge (2-D
+ * star-formation-history datasets with their own shape and write path).
+ *
+ * SAGE26 -- released under MIT (see LICENSE).
+ */
+
+#pragma once
+
+#define GALAXY_OUTPUT_FIELDS(X) \
+    X(SnapNum, SnapNum, int32_t, H5T_NATIVE_INT, \
+      "Snapshot the galaxy is located at.", \
+      "Unitless") \
+    X(Type, Type, int32_t, H5T_NATIVE_INT, \
+      "0: Central galaxy of the main FoF halo. 1: Central of a sub-halo. 2: Orphan galaxy that will merge within the current timestep.", \
+      "Unitless") \
+    X(GalaxyIndex, GalaxyIndex, long long, H5T_NATIVE_LLONG, \
+      "Galaxy ID, unique across all trees and files. Calculated as local galaxy number + tree number * factor + file number * factor ", \
+      "Unitless") \
+    X(CentralGalaxyIndex, CentralGalaxyIndex, long long, H5T_NATIVE_LLONG, \
+      "GalaxyIndex of the central galaxy within this galaxy's FoF group.  Calculated the same as 'GalaxyIndex'.", \
+      "Unitless") \
+    X(SAGEHaloIndex, SAGEHaloIndex, int32_t, H5T_NATIVE_INT, \
+      "Halo number from the restructured trees. This is different to the tree file because we order the trees. Note: This is the host halo, not necessarily the main FoF halo.", \
+      "Unitless") \
+    X(SAGETreeIndex, SAGETreeIndex, int32_t, H5T_NATIVE_INT, \
+      "Tree number this galaxy belongs to.", \
+      "Unitless") \
+    X(SimulationHaloIndex, SimulationHaloIndex, long long, H5T_NATIVE_LLONG, \
+      "Most bound particle ID from the tree files.", \
+      "Unitless") \
+    X(mergeType, mergeType, int32_t, H5T_NATIVE_INT, \
+      "Denotes how this galaxy underwent a merger. 0: None. 1: Minor merger. 2: Major merger. 3: Disk instability. 4: Disrupt to intra-cluster stars.", \
+      "Unitless") \
+    X(mergeIntoID, mergeIntoID, int32_t, H5T_NATIVE_INT, \
+      "Galaxy ID this galaxy is merging into.", \
+      "Unitless") \
+    X(mergeIntoSnapNum, mergeIntoSnapNum, int32_t, H5T_NATIVE_INT, \
+      "Snapshot number of the galaxy this galaxy is merging into.", \
+      "Unitless") \
+    X(dT, dT, float, H5T_NATIVE_FLOAT, \
+      "Time between this snapshot and when the galaxy was last evolved.", \
+      "Myr") \
+    X(Posx, Posx, float, H5T_NATIVE_FLOAT, \
+      "Galaxy spatial x position.", \
+      "Mpc/h") \
+    X(Posy, Posy, float, H5T_NATIVE_FLOAT, \
+      "Galaxy spatial y position.", \
+      "Mpc/h") \
+    X(Posz, Posz, float, H5T_NATIVE_FLOAT, \
+      "Galaxy spatial z position.", \
+      "Mpc/h") \
+    X(Velx, Velx, float, H5T_NATIVE_FLOAT, \
+      "Galaxy velocity in x direction.", \
+      "km/s") \
+    X(Vely, Vely, float, H5T_NATIVE_FLOAT, \
+      "Galaxy velocity in y direction.", \
+      "km/s") \
+    X(Velz, Velz, float, H5T_NATIVE_FLOAT, \
+      "Galaxy velocity in z direction.", \
+      "km/s") \
+    X(Spinx, Spinx, float, H5T_NATIVE_FLOAT, \
+      "Halo spin in the x direction.", \
+      "Mpc * km/s") \
+    X(Spiny, Spiny, float, H5T_NATIVE_FLOAT, \
+      "Halo spin in the y direction.", \
+      "Mpc * km/s") \
+    X(Spinz, Spinz, float, H5T_NATIVE_FLOAT, \
+      "Halo spin in the z direction.", \
+      "Mpc * km/s") \
+    X(Len, Len, int32_t, H5T_NATIVE_INT, \
+      "Number of particles in this galaxy's halo.", \
+      "Unitless") \
+    X(Mvir, Mvir, float, H5T_NATIVE_FLOAT, \
+      "Virial mass of this galaxy's halo.", \
+      "1.0e10 Msun/h") \
+    X(CentralMvir, CentralMvir, float, H5T_NATIVE_FLOAT, \
+      "Virial mass of the main FoF halo.", \
+      "1.0e10 Msun/h") \
+    X(Rvir, Rvir, float, H5T_NATIVE_FLOAT, \
+      "Virial radius of this galaxy's halo.", \
+      "Mpc/h") \
+    X(Vvir, Vvir, float, H5T_NATIVE_FLOAT, \
+      "Virial velocity of this galaxy's halo.", \
+      "km/s") \
+    X(Vmax, Vmax, float, H5T_NATIVE_FLOAT, \
+      "Maximum circular speed for this galaxy's halo.", \
+      "km/s") \
+    X(VelDisp, VelDisp, float, H5T_NATIVE_FLOAT, \
+      "Velocity dispersion for this galaxy's halo.", \
+      "km/s") \
+    X(ColdGas, ColdGas, float, H5T_NATIVE_FLOAT, \
+      "Mass of gas in the cold reseroivr.", \
+      "1.0e10 Msun/h") \
+    X(StellarMass, StellarMass, float, H5T_NATIVE_FLOAT, \
+      "Mass of stars.", \
+      "1.0e10 Msun/h") \
+    X(BulgeMass, BulgeMass, float, H5T_NATIVE_FLOAT, \
+      "Mass of stars in the bulge. Bulge stars are added either through disk instabilities or mergers.", \
+      "1.0e10 Msun/h") \
+    X(HotGas, HotGas, float, H5T_NATIVE_FLOAT, \
+      "Mass of gas in the hot reservoir.", \
+      "1.0e10 Msun/h") \
+    X(EjectedMass, EjectedMass, float, H5T_NATIVE_FLOAT, \
+      "Mass of gass in the ejected reseroivr.", \
+      "1.0e10 Msun/h") \
+    X(BlackHoleMass, BlackHoleMass, float, H5T_NATIVE_FLOAT, \
+      "Mass of this galaxy's black hole.", \
+      "1.0e10 Msun/h") \
+    X(IntraClusterStars, ICS, float, H5T_NATIVE_FLOAT, \
+      "Mass of intra-cluster stars.", \
+      "1.0e10 Msun/h") \
+    X(MetalsColdGas, MetalsColdGas, float, H5T_NATIVE_FLOAT, \
+      "Mass of metals in the cold reseroivr.", \
+      "1.0e10 Msun/h") \
+    X(MetalsStellarMass, MetalsStellarMass, float, H5T_NATIVE_FLOAT, \
+      "Mass of metals in stars.", \
+      "1.0e10 Msun/h") \
+    X(MetalsBulgeMass, MetalsBulgeMass, float, H5T_NATIVE_FLOAT, \
+      "Mass of metals in the bulge.", \
+      "1.0e10 Msun/h") \
+    X(MetalsHotGas, MetalsHotGas, float, H5T_NATIVE_FLOAT, \
+      "Mass of metals in the hot reservoir.", \
+      "1.0e10 Msun/h") \
+    X(MetalsEjectedMass, MetalsEjectedMass, float, H5T_NATIVE_FLOAT, \
+      "Mass of metals in the ejected reseroivr.", \
+      "1.0e10 Msun/h") \
+    X(MetalsIntraClusterStars, MetalsICS, float, H5T_NATIVE_FLOAT, \
+      "Mass of metals in intra-cluster stars.", \
+      "1.0e10 Msun/h") \
+    X(SfrDisk, SfrDisk, float, H5T_NATIVE_FLOAT, \
+      "Star formation rate within the disk.", \
+      "Msun/yr") \
+    X(SfrBulge, SfrBulge, float, H5T_NATIVE_FLOAT, \
+      "Star formation rate within the bulge.", \
+      "Msun/yr") \
+    X(SfrDiskZ, SfrDiskZ, float, H5T_NATIVE_FLOAT, \
+      "Average metallicity of star-forming disk gas.", \
+      "Msun/yr") \
+    X(SfrBulgeZ, SfrBulgeZ, float, H5T_NATIVE_FLOAT, \
+      "Average metallicity of star-forming bulge gas.", \
+      "Msun/yr") \
+    X(DiskRadius, DiskScaleRadius, float, H5T_NATIVE_FLOAT, \
+      "Disk scale radius based on Mo, Shude & White (1998)", \
+      "Mpc/h") \
+    X(BulgeRadius, BulgeRadius, float, H5T_NATIVE_FLOAT, \
+      "Bulge scale radius based on Lange et al. (2015), Shen et al. (2003)", \
+      "Mpc/h") \
+    X(MergerBulgeRadius, MergerBulgeRadius, float, H5T_NATIVE_FLOAT, \
+      "Bulge radius formed from mergers (classical bulge).", \
+      "Mpc/h") \
+    X(InstabilityBulgeRadius, InstabilityBulgeRadius, float, H5T_NATIVE_FLOAT, \
+      "Bulge radius formed from disk instabilities (pseudo-bulge).", \
+      "Mpc/h") \
+    X(MergerBulgeMass, MergerBulgeMass, float, H5T_NATIVE_FLOAT, \
+      "Mass of stars in the bulge formed from mergers.", \
+      "1.0e10 Msun/h") \
+    X(InstabilityBulgeMass, InstabilityBulgeMass, float, H5T_NATIVE_FLOAT, \
+      "Mass of stars in the bulge formed from disk instabilities.", \
+      "1.0e10 Msun/h") \
+    X(Cooling, Cooling, float, H5T_NATIVE_FLOAT, \
+      "Energy rate for gas cooling in the galaxy.", \
+      "erg/s") \
+    X(Heating, Heating, float, H5T_NATIVE_FLOAT, \
+      "Energy rate for gas heating in the galaxy.", \
+      "erg/s") \
+    X(QuasarModeBHaccretionMass, QuasarModeBHaccretionMass, float, H5T_NATIVE_FLOAT, \
+      "Mass that this galaxy's black hole accreted during the last time step.", \
+      "1.0e10 Msun/h") \
+    X(TimeOfLastMajorMerger, TimeOfLastMajorMerger, float, H5T_NATIVE_FLOAT, \
+      "Time since this galaxy had a major merger.", \
+      "Myr") \
+    X(TimeOfLastMinorMerger, TimeOfLastMinorMerger, float, H5T_NATIVE_FLOAT, \
+      "Time since this galaxy had a minor merger.", \
+      "Myr") \
+    X(OutflowRate, OutflowRate, float, H5T_NATIVE_FLOAT, \
+      "Rate at which cold gas is reheated to hot gas.", \
+      "Msun/yr") \
+    X(infallMvir, infallMvir, float, H5T_NATIVE_FLOAT, \
+      "Virial mass of this galaxy's halo at the previous timestep.", \
+      "1.0e10 Msun/yr") \
+    X(infallVvir, infallVvir, float, H5T_NATIVE_FLOAT, \
+      "Virial velocity of this galaxy's halo at the previous timestep.", \
+      "km/s") \
+    X(infallVmax, infallVmax, float, H5T_NATIVE_FLOAT, \
+      "Maximum circular speed of this galaxy's halo at the previous timestep.", \
+      "km/s") \
+    X(infallStellarMass, infallStellarMass, float, H5T_NATIVE_FLOAT, \
+      "Stellar mass of this galaxy at the time it became a satellite.", \
+      "1.0e10 Msun/h") \
+    X(Regime, Regime, int32_t, H5T_NATIVE_INT, \
+      "Regime of gas accretion onto this galaxy's halo: 0 = CGM-regime 1 = ICM-regime.", \
+      "Unitless") \
+    X(CGMgas, CGMgas, float, H5T_NATIVE_FLOAT, \
+      "Mass of gas in the circum-galactic medium (CGM).", \
+      "1.0e10 Msun/h") \
+    X(MetalsCGMgas, MetalsCGMgas, float, H5T_NATIVE_FLOAT, \
+      "Mass of metals in the circum-galactic medium (CGM).", \
+      "1.0e10 Msun/h") \
+    X(MassLoading, MassLoading, float, H5T_NATIVE_FLOAT, \
+      "Mass loading factor defined as the ratio of outflow rate to star formation rate.", \
+      "Unitless") \
+    X(H2gas, H2gas, float, H5T_NATIVE_FLOAT, \
+      "Mass of molecular hydrogen (H2) in the cold gas reservoir.", \
+      "1.0e10 Msun/h") \
+    X(H1gas, H1gas, float, H5T_NATIVE_FLOAT, \
+      "Mass of atomic hydrogen (HI) in the cold gas reservoir.", \
+      "1.0e10 Msun/h") \
+    X(tcool, tcool, float, H5T_NATIVE_FLOAT, \
+      "Cooling time of the CGM gas in the halo.", \
+      "Myr") \
+    X(tff, tff, float, H5T_NATIVE_FLOAT, \
+      "Free-fall time of the CGM gas in the halo.", \
+      "Myr") \
+    X(tcool_over_tff, tcool_over_tff, float, H5T_NATIVE_FLOAT, \
+      "Ratio of cooling time to free-fall time of the CGM gas in the halo.", \
+      "Unitless") \
+    X(tdeplete, tdeplete, float, H5T_NATIVE_FLOAT, \
+      "Depletion time of the CGM gas reservoir.", \
+      "Myr") \
+    X(H2DepletionTime_Gyr, H2DepletionTime_Gyr, float, H5T_NATIVE_FLOAT, \
+      "H2 depletion time from the K13 prescription. -1 if not applicable.", \
+      "Gyr") \
+    X(RcoolToRvir, RcoolToRvir, float, H5T_NATIVE_FLOAT, \
+      "Ratio of the cooling radius to the virial radius of the halo.", \
+      "Unitless") \
+    X(TimeOfInfall, TimeOfInfall, float, H5T_NATIVE_FLOAT, \
+      "Time when the galaxy last became a satellite galaxy.", \
+      "Myr") \
+    X(FFBRegime, FFBRegime, int32_t, H5T_NATIVE_INT, \
+      "FFB Regime of this galaxy's halo: 0 = Normal halo 1 = FFB halo.", \
+      "Unitless") \
+    X(Concentration, Concentration, float, H5T_NATIVE_FLOAT, \
+      "NFW halo concentration parameter from Ishiyama+21 c-M relation.", \
+      "Unitless") \
+    X(mdot_cool, mdot_cool, float, H5T_NATIVE_FLOAT, \
+      "Cooling rate of hot halo gas.", \
+      "1.0e10 Msun/yr") \
+    X(mdot_stream, mdot_stream, float, H5T_NATIVE_FLOAT, \
+      "Cooling rate of cold streams.", \
+      "1.0e10 Msun/yr") \
+    X(ICS_disrupt, ICS_disrupt, float, H5T_NATIVE_FLOAT, \
+      "Cumulative stellar mass disrupted to ICS (tracks assembly).", \
+      "1.0e10 Msun/h") \
+    X(ICS_accrete, ICS_accrete, float, H5T_NATIVE_FLOAT, \
+      "Cumulative ICS accreted from satellites (tracks assembly).", \
+      "1.0e10 Msun/h") \
+    X(ICS_sum_mt, ICS_sum_mt, float, H5T_NATIVE_FLOAT, \
+      "Mass-weighted sum m*t (code time) at ICS deposition; divide by (ICS_disrupt+ICS_accrete) for mean assembly lookback.", \
+      "1.0e10 Msun/h * code_time") \
+    X(g_max, g_max, double, H5T_NATIVE_DOUBLE, \
+      "Maximum g value for this galaxy's halo across all snapshots.", \
+      "1.0e10 Msun/h") \
+    X(r_heat, r_heat, float, H5T_NATIVE_FLOAT, \
+      "AGN radio-mode heating radius (ratchet, capped at Rvir in the CGM regime). Cooling is suppressed at r < r_heat.", \
+      "Mpc/h")

--- a/src/model_cooling_heating.c
+++ b/src/model_cooling_heating.c
@@ -454,16 +454,12 @@ double cooling_recipe_hot(const int gal, const double dt, struct GALAXY *galaxie
         if(rcool > galaxies[gal].Rvir) rcool = galaxies[gal].Rvir;
 
         coolingGas = 0.0;
-        
+
         if(run_params->CGMrecipeOn == 0) {
-            // Original behavior: SAGE C16 cooling recipe
-            if(rcool > galaxies[gal].Rvir) {
-                // "cold accretion" regime
-                coolingGas = galaxies[gal].HotGas / (galaxies[gal].Rvir / galaxies[gal].Vvir) * dt;
-            } else {
-                // "hot halo cooling" regime
-                coolingGas = (galaxies[gal].HotGas / galaxies[gal].Rvir) * (rcool / (2.0 * tcool)) * dt;
-            }
+            // SAGE C16 hot-halo cooling. rcool was capped at Rvir above, so the
+            // historical rcool > Rvir "cold accretion" branch is unreachable:
+            // cooling saturates at 0.5 * m_hot / t_cool instead of jumping.
+            coolingGas = (galaxies[gal].HotGas / galaxies[gal].Rvir) * (rcool / (2.0 * tcool)) * dt;
         } else {
             // CGMrecipeOn == 1: D&B06 cold streams for hot-regime halos
             // All halos here are in the hot regime (have virial shocks)

--- a/src/model_disk_instability.c
+++ b/src/model_disk_instability.c
@@ -45,7 +45,7 @@ static const double TOOMRE_DISK_FACTOR = 3.0;
  * transfer so the Tonini formula uses the pre-instability disc scale.
  */
 void check_disk_instability(const int p, const int centralgal, const int halonr, const double time, const double dt, const int step,
-                            struct GALAXY *galaxies, struct params *run_params)
+                            struct GALAXY *galaxies, const struct params *run_params)
 {
     // Here we calculate the stability of the stellar and gaseous disk as discussed in Mo, Mao & White (1998).
     // For unstable stars and gas, we transfer the required amount to the bulge to make the disk stable again
@@ -91,7 +91,10 @@ void check_disk_instability(const int p, const int centralgal, const int halonr,
 #ifdef VERBOSE
             if(unstable_gas > 1.0001 * galaxies[p].ColdGas ) {
                 fprintf(stdout, "unstable_gas > galaxies[p].ColdGas\t%e\t%e\n", unstable_gas, galaxies[p].ColdGas);
-                run_params->interrupted = 1;
+                /* progressbar redraw flag -- the only mutation of run_params in the
+                   physics modules, so the const is cast away here rather than
+                   forcing a non-const signature onto every caller. */
+                ((struct params *) run_params)->interrupted = 1;
             }
 #endif
 

--- a/src/model_disk_instability.h
+++ b/src/model_disk_instability.h
@@ -18,7 +18,7 @@ extern "C" {
 
     /* functions in model_disk_instability.c */
     extern void check_disk_instability(const int p, const int centralgal, const int halonr, const double time, const double dt, const int step,
-                                       struct GALAXY *galaxies, struct params *run_params);
+                                       struct GALAXY *galaxies, const struct params *run_params);
     
 
 #ifdef __cplusplus

--- a/src/model_infall.c
+++ b/src/model_infall.c
@@ -2,12 +2,14 @@
  * model_infall.c -- baryon infall, satellite stripping, and reionisation.
  *
  * Implements four routines called from evolve_galaxies() each timestep:
- *   infall_recipe      -- computes the net infalling mass for a central halo
- *                         and routes it to the correct reservoir (HotGas or
- *                         CGMgas) via add_infall_to_hot(); calls
- *                         strip_from_satellite() for each satellite.
- *   strip_from_satellite -- removes all remaining gas from a satellite galaxy
- *                           and adds it to the central's hot/CGM reservoir.
+ *   infall_recipe      -- computes the net infalling mass for a central halo,
+ *                         pools satellite ejecta/ICS into the central, and
+ *                         migrates the central's gas between the HotGas and
+ *                         CGMgas reservoirs according to its regime.
+ *   strip_from_satellite -- removes part of a satellite's baryon excess
+ *                           (scheme-dependent, see PhysicalStrippingOn) and
+ *                           adds it to the central's hot/CGM reservoir;
+ *                           called from evolve_galaxies().
  *   do_reionization    -- computes the reionisation suppression factor for
  *                         low-mass haloes using the Gnedin (2000) model.
  *   add_infall_to_hot  -- adds (or subtracts) infallingGas to the appropriate

--- a/src/model_mergers.c
+++ b/src/model_mergers.c
@@ -773,7 +773,7 @@ void collisional_starburst_recipe(const double mass_ratio, const int merger_cent
     // check for disk instability
     if(run_params->DiskInstabilityOn && mode == 0) {
         if(mass_ratio < run_params->ThreshMajorMerger) {
-            check_disk_instability(merger_centralgal, centralgal, halonr, time, dt, step, galaxies, (struct params *) run_params);
+            check_disk_instability(merger_centralgal, centralgal, halonr, time, dt, step, galaxies, run_params);
         }
     }
 

--- a/src/model_starformation_and_feedback.c
+++ b/src/model_starformation_and_feedback.c
@@ -693,7 +693,7 @@ void starformation_and_feedback(const int p, const int centralgal, const double 
 
     // check for disk instability
     if(run_params->DiskInstabilityOn) {
-        check_disk_instability(p, centralgal, halonr, time, dt, step, galaxies, (struct params *) run_params);
+        check_disk_instability(p, centralgal, halonr, time, dt, step, galaxies, run_params);
     }
 
     // formation of new metals - instantaneous recycling approximation - only SNII


### PR DESCRIPTION
## Summary

Follow-up to #18, same rules: every commit gated on the byte-identical regression baseline (5,444 datasets), the binary benchmark, and the 559-test unit suite.

## Changes

- **Single source of truth for the 82 HDF5 output fields** (`io/save_gals_hdf5_fields.h`): the buffer struct, the four metadata tables, the malloc/free/write stacks, and `NUM_OUTPUT_FIELDS` are all generated from one X-macro table. Adding an output field is now one table entry + one buffer-fill line, instead of seven hand-synchronized edits. Equivalence proven by preprocessor expansion (names, descriptions, units, dtypes, and write order byte-identical to the old tables) on top of the usual output verification.
- **Malformed parameter values are now startup errors**: `strtod`/`strtol` with full-consumption checks replace `atof`/`atoi`, which silently turned typos like `O.05` into 0.0 and let runs proceed with wrong physics.
- **Const-correctness & robustness**: `check_disk_instability` takes const params (the progressbar flag write is documented at its single mutation site); the `OutputGalCount` VLA replaced with a bounded fixed array; `NULL` pointer init.

## Tree-file I/O audit (requested)

Checked every reader for repeated open/close. All of them — including `lhalo_binary`, used by both Millennium and microUchuu — open each tree file only 2–3 times at startup (header scan, load-balancing table, persistent open) and hold descriptors for the whole run; each forest load is a single `pread` at a precomputed offset. No per-forest reopening exists; nothing to fix.

## Verification

- millennium + millennium_all: all 5,444 datasets bit-identical
- Binary benchmark: 64 files match
- Unit tests: 559 tests / 18 suites pass